### PR TITLE
Add Conv3d import

### DIFF
--- a/tests/test_conv3d.py
+++ b/tests/test_conv3d.py
@@ -1,0 +1,10 @@
+import pytest
+from ultralytics.nn.tasks import yaml_model_load, parse_model
+from ultralytics.nn.modules import Conv3d
+
+
+def test_conv3d_yaml_loading():
+    cfg_path = 'ultralytics/cfg/models/12/yolo12-mf.yaml'
+    cfg = yaml_model_load(cfg_path)
+    model, _ = parse_model(cfg.copy(), ch=3, verbose=False)
+    assert any(isinstance(m, Conv3d) for m in model.modules())

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -104,6 +104,7 @@ from .transformer import (
 
 __all__ = (
     "Conv",
+    "Conv3d",
     "Conv2",
     "LightConv",
     "RepConv",

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -41,6 +41,7 @@ from ultralytics.nn.modules import (
     Classify,
     Concat,
     Conv,
+    Conv3d,
     Conv2,
     ConvTranspose,
     Detect,


### PR DESCRIPTION
## Summary
- export Conv3d from `ultralytics.nn.modules`
- import Conv3d in `ultralytics.nn.tasks`
- test Conv3d YAML model parsing

## Testing
- `pytest tests/test_conv3d.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*