### PR TITLE
Expand YOLOMultiFrameDataset docstring

### DIFF
--- a/ultralytics/data/multi_frame_dataset.py
+++ b/ultralytics/data/multi_frame_dataset.py
@@ -5,7 +5,37 @@ import numpy as np
 from .dataset import YOLODataset
 
 class YOLOMultiFrameDataset(YOLODataset):
-    """Dataset that loads stacks of frames listed in *.frames.txt files."""
+    """Dataset that loads a stack of sequential frames for each sample.
+
+    The dataset expects a ``.frames.txt`` file alongside every image (or in a
+    ``history_dir`` folder) that lists the neighbouring frame paths. Each file is
+    newline separated and should contain ``n_history`` previous frames followed by
+    the current image path::
+
+        /dataset/images/img_000123.jpg
+        /dataset/images/img_000124.jpg
+        ...
+        /dataset/images/img_000128.jpg
+
+    ``n_history`` defines how many historical frames are described in the text
+    files. When present, ``load_image`` reads all paths, resizes them to the
+    target dimensions and returns a NumPy array of shape ``(T, H, W, C)`` where
+    ``T`` equals ``n_history + 1`` (the stack depth). If no ``.frames.txt`` is
+    found, only the current frame is loaded.
+
+    Example:
+
+        >>> from ultralytics.data import YOLOMultiFrameDataset
+        >>> data = {
+        ...     'train': '/path/to/train/images',
+        ...     'nc': 1,
+        ...     'names': {0: 'object'},
+        ...     'channels': 3,
+        ... }
+        >>> dset = YOLOMultiFrameDataset(img_path=data['train'], data=data, n_history=5)
+        >>> imgs, _, _ = dset.load_image(0)
+        >>> print(imgs.shape)  # (6, H, W, 3)
+    """
 
     def __init__(self, *args, n_history=5, history_dir="history_maps", **kwargs):
         self.n_history = n_history


### PR DESCRIPTION
## Summary
- clarify `.frames.txt` file layout in YOLOMultiFrameDataset
- document `n_history` and returned image stack
- add example usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*